### PR TITLE
Fix incorrect minimum game number

### DIFF
--- a/frontend/src/misc.ts
+++ b/frontend/src/misc.ts
@@ -24,8 +24,23 @@ export function getLocationNumber(date: Date): number {
   }
 
   console.log("day_number", day_number);
-  // Select a random number between 0 and 639 based on
-  const result = Math.round(seededRandom(day_number, 1, 639));
+
+  const max_game = 639;
+
+  // Select a random number between 1 and 639 based on the day.
+  // Previous days used an incorrect minimum value. Continue to use it so the history stays the same.
+  if (day_number <= 1378) {
+    const result = Math.round(seededRandom(day_number, 0, max_game));
+
+    // If result lands at 0, don't return and switch to the corrected randomiser since game 0 doesn't exist.
+    if (result > 0) {
+      console.log("result", result);
+      return result;
+    }
+  }
+
+  // Randomiser with corrected minimum value
+  const result = Math.round(seededRandom(day_number, 1, max_game));
   console.log("result", result);
   return result;
 }

--- a/frontend/src/misc.ts
+++ b/frontend/src/misc.ts
@@ -25,7 +25,7 @@ export function getLocationNumber(date: Date): number {
 
   console.log("day_number", day_number);
   // Select a random number between 0 and 639 based on
-  const result = Math.round(seededRandom(day_number, 0, 639));
+  const result = Math.round(seededRandom(day_number, 1, 639));
   console.log("result", result);
   return result;
 }


### PR DESCRIPTION
Today the random game selector landed on the number 0, but since there is no game 0 the game crashed.

This does re-randomize all old games/days. So I could add an if statement that causes it to use the new minimum value from today onwards and leave all previous games intact.